### PR TITLE
ci: rename the gate job to 'CI Gate'

### DIFF
--- a/.github/workflows/pr-monitor.yml
+++ b/.github/workflows/pr-monitor.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   monitor:
-    name: Check All Workflows
+    name: 'CI Gate'
     runs-on: ubuntu-latest
     # The action has no timeout of its own — this is the backstop. If a predicted
     # run never dispatches, the gate waits here until the job is killed.


### PR DESCRIPTION
Aligns this repo with the fleet: the required check context is the job
name, and every other repo emits `CI Gate`. Renaming here lets one ruleset
shape apply everywhere.

The PR that renames the job also runs it, so this satisfies its own gate.